### PR TITLE
fix:  set base cell and color swatch rendering to 12x12 boxes

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -66,7 +66,7 @@
       #hud-colors.visible { display: flex; }
       .color-swatch {
         width: 12px;
-        height: 18px;
+        height: 12px;
         cursor: pointer;
         outline: 1px solid transparent;
         outline-offset: 2px;
@@ -199,7 +199,7 @@
     <script>
       const CHUNK_SIZE = 50;
       const BASE_CELL_W = 12;
-      const BASE_CELL_H = 18;
+      const BASE_CELL_H = 12;
 
       const canvas = document.getElementById('canvas');
       const ctx = canvas.getContext('2d');


### PR DESCRIPTION
Set bounding boxes for character rendering to 12x12, matching the original width, which preserves spacing between characters. 

As courier new doesn't have a perfect aspect ratio, characters are naturally taller than they are wide. While this change does not break character rendering, it does result in vertical spacing between lines of characters to be smaller than the horizontal spacing.

The `.color-swatch` picker for authenticated users has also been updated to reflect this change. 

Closes #15

