### PR TITLE
feature: add ability to write to tiles unclaimed

### DIFF
--- a/main.py
+++ b/main.py
@@ -264,15 +264,17 @@ async def process_message(message: Message, websocket: WebSocket) -> None:
             return
         if not (0 <= message["s_x"] < CHUNK_SIZE and 0 <= message["s_y"] < CHUNK_SIZE):
             return
-        effective_user_id = ("u:" + user_payload["sub"]) if user_payload else None
+        real_user_id = ("u:" + user_payload["sub"]) if user_payload else None
+        effective_user_id = None if message.get("unclaimed") else real_user_id
+
         existing_owner: str | None = None
-        if not auth.NO_AUTH and effective_user_id:
+        if not auth.NO_AUTH:
             existing = app.data.get(g_x=message["g_x"], g_y=message["g_y"])[message["s_x"]][message["s_y"]]
             existing_owner = existing[1]
             if existing_owner and existing_owner.startswith("u:") and existing_owner != effective_user_id:
                 return
             # Enforce tile allowance for new claims
-            if message["data"] and existing_owner is None:
+            if effective_user_id and message["data"] and existing_owner is None:
                 sub = effective_user_id[2:]  # strip "u:" prefix
                 claimed = app.user_id_to_claimed.get(sub, 0)
                 allowance = app.user_id_to_allowance.get(sub, 100)

--- a/static/index.html
+++ b/static/index.html
@@ -36,11 +36,19 @@
       #hud-tiles.visible { display: block; }
       #hud-tiles.at-limit { color: #6a3030; }
 
-      #hud-unclaimed { display: none; align-items: center; gap: 6px; pointer-events: auto; margin-top: 2px; }
-      #hud-unclaimed.visible { display: flex; }
-      #hud-unclaimed label { cursor: pointer; opacity: 0.6; transition: opacity 0.2s, color 0.2s; }
-      #hud-unclaimed:hover label { opacity: 1; color: #6a8aaa; }
-      #hud-unclaimed input { cursor: pointer; margin: 0; }
+      #hud-unclaimed { display: none; pointer-events: auto; margin-top: 2px; }
+      #hud-unclaimed.visible { display: block; }
+      #unclaimed-checkbox { display: none; }
+      #hud-unclaimed label { 
+        cursor: pointer; 
+        color: #3d4a5c; 
+        transition: color 0.2s; 
+        letter-spacing: 1px; 
+        user-select: none;
+      }
+      #hud-unclaimed:hover label { color: #6a8aaa; }
+      #unclaimed-label-box::before { content: "[ ] "; }
+      #unclaimed-checkbox:checked + label #unclaimed-label-box::before { content: "[x] "; }
 
       #hud-auth { pointer-events: auto; }
       #hud-auth a {
@@ -218,7 +226,7 @@
         <div id="hud-colors"></div>
         <div id="hud-unclaimed">
           <input type="checkbox" id="unclaimed-checkbox">
-          <label for="unclaimed-checkbox">write unclaimed</label>
+          <label for="unclaimed-checkbox"><span id="unclaimed-label-box"></span>write unclaimed</label>
         </div>
         <div id="hud-tiles"></div>
         <div id="hud-help">drag to pan &nbsp; click to place cursor &nbsp; type to write</div>

--- a/static/index.html
+++ b/static/index.html
@@ -36,6 +36,12 @@
       #hud-tiles.visible { display: block; }
       #hud-tiles.at-limit { color: #6a3030; }
 
+      #hud-unclaimed { display: none; align-items: center; gap: 6px; pointer-events: auto; margin-top: 2px; }
+      #hud-unclaimed.visible { display: flex; }
+      #hud-unclaimed label { cursor: pointer; opacity: 0.6; transition: opacity 0.2s, color 0.2s; }
+      #hud-unclaimed:hover label { opacity: 1; color: #6a8aaa; }
+      #hud-unclaimed input { cursor: pointer; margin: 0; }
+
       #hud-auth { pointer-events: auto; }
       #hud-auth a {
         color: #3d4a5c;
@@ -210,6 +216,10 @@
         <div id="hud-status" class="disconnected">connecting</div>
         <div id="hud-auth"></div>
         <div id="hud-colors"></div>
+        <div id="hud-unclaimed">
+          <input type="checkbox" id="unclaimed-checkbox">
+          <label for="unclaimed-checkbox">write unclaimed</label>
+        </div>
         <div id="hud-tiles"></div>
         <div id="hud-help">drag to pan &nbsp; click to place cursor &nbsp; type to write</div>
       </div>
@@ -362,6 +372,9 @@
           if (isAuthenticated || isAnonAuth) {
             myCursorColor = data.cursor_color || CURSOR_COLORS[0];
             renderUsername(data.username, myCursorColor);
+            if (isAuthenticated && !isAnonAuth) {
+              document.getElementById('hud-unclaimed').classList.add('visible');
+            }
           } else {
             hudAuth.innerHTML = `<a href="/auth/discord/login">login</a>`;
           }
@@ -442,6 +455,8 @@
         if (!Array.isArray(cell)) return true;
         const existingOwner = cell[1];
         if (!existingOwner || !existingOwner.startsWith('u:')) return true;
+        const isUnclaimed = document.getElementById('unclaimed-checkbox').checked;
+        if (isUnclaimed) return false;
         return existingOwner === myUserId;
       }
 
@@ -452,7 +467,8 @@
         }
         if (!canWrite(wx, wy)) return;
         const { gx, gy, sx, sy } = worldToChunk(wx, wy);
-        if (ch && myUserId) {
+        const isUnclaimed = document.getElementById('unclaimed-checkbox').checked;
+        if (ch && myUserId && !isUnclaimed) {
           const existingCell = chunks.get(`${gx},${gy}`)?.[sx]?.[sy];
           const existingOwner = Array.isArray(existingCell) ? existingCell[1] : null;
           if ((!existingOwner || !existingOwner.startsWith('u:')) && myTileClaimed >= myTileAllowance) return;
@@ -461,10 +477,10 @@
         if (!chunks.has(key)) {
           chunks.set(key, Array.from({ length: CHUNK_SIZE }, () => Array.from({ length: CHUNK_SIZE }, () => ['', null])));
         }
-        chunks.get(key)[sx][sy] = ch ? [ch, myUserId] : ['', null];
+        chunks.get(key)[sx][sy] = ch ? [ch, myUserId && !isUnclaimed ? myUserId : null] : ['', null];
         if (!ws || ws.readyState !== WebSocket.OPEN) return;
         requestChunk(gx, gy);
-        ws.send(JSON.stringify({ type: 'set', g_x: gx, g_y: gy, s_x: sx, s_y: sy, data: ch }));
+        ws.send(JSON.stringify({ type: 'set', g_x: gx, g_y: gy, s_x: sx, s_y: sy, data: ch, unclaimed: isUnclaimed }));
       }
 
       function sendCursorMove(wx, wy) {


### PR DESCRIPTION
Added ability for authenticated users to write to tiles in unclaimed mode when `NO_AUTH` is set to no by setting `effective_user_id` to None and writing None to `user_id` for the canvas tile DB entry, using a visible toggle in the top right underneath the color picker. 

This allows for users to type on the board without claiming tiles or using their tile allowance. 

Users cannot overwrite claimed tiles in unclaimed mode, even their own. Unclaimed tiles, whether occupied by a character or not can be overwritten and claimed by any user in any mode. 

Usernames and cursor locations will display identically to existing behavior regardless of which mode a user is in. 

`user_payload` will still enforce that only authenticated users can populate the canvas in any mode.

Known issue: The visual write unclaimed checkbox still appears when running in NO_AUTH mode, but will not do anything. 
This is due to users maintaining an anonymous identity. A fix would be trivial in `async def me`, but is out of scope for this PR.

Closes #28 

